### PR TITLE
Add Context Functions

### DIFF
--- a/cnuodb.cpp
+++ b/cnuodb.cpp
@@ -302,8 +302,8 @@ int nuodb_statement_set_query_micros(struct nuodb *db, struct nuodb_statement *s
     try {
         if (st) {
             PreparedStatement *stmt = reinterpret_cast<PreparedStatement *>(st);
+            // Set the timeout in micro seconds; zero means there is no limit.
             stmt->setQueryTimeoutMicros(timeout_micro_seconds);
-            st = 0;
         }
         return 0;
     } catch (SQLException &e) {

--- a/cnuodb.cpp
+++ b/cnuodb.cpp
@@ -164,10 +164,11 @@ static int fetchExecuteResult(struct nuodb *db, Statement *stmt,
 }
 
 int nuodb_execute(struct nuodb *db, const char *sql,
-                  int64_t *rows_affected, int64_t *last_insert_id) {
+                  int64_t *rows_affected, int64_t *last_insert_id, int64_t timeout_micro_seconds) {
     Statement *stmt = 0;
     try {
         stmt = db->conn->createStatement();
+        stmt->setQueryTimeoutMicros(timeout_micro_seconds);
         stmt->executeUpdate(sql, RETURN_GENERATED_KEYS);
         int rc = fetchExecuteResult(db, stmt, rows_affected, last_insert_id);
         stmt->close();
@@ -289,6 +290,20 @@ int nuodb_statement_close(struct nuodb *db, struct nuodb_statement **st) {
             PreparedStatement *stmt = reinterpret_cast<PreparedStatement *>(*st);
             stmt->close();
             *st = 0;
+        }
+        return 0;
+    } catch (SQLException &e) {
+        return setError(db, e);
+    }
+}
+
+int nuodb_statement_set_query_micros(struct nuodb *db, struct nuodb_statement *st,
+                                     int64_t timeout_micro_seconds) {
+    try {
+        if (st) {
+            PreparedStatement *stmt = reinterpret_cast<PreparedStatement *>(st);
+            stmt->setQueryTimeoutMicros(timeout_micro_seconds);
+            st = 0;
         }
         return 0;
     } catch (SQLException &e) {

--- a/cnuodb.h
+++ b/cnuodb.h
@@ -49,13 +49,14 @@ int nuodb_autocommit(struct nuodb *db, int *state);
 int nuodb_autocommit_set(struct nuodb *db, int state);
 int nuodb_commit(struct nuodb *db);
 int nuodb_rollback(struct nuodb *db);
-int nuodb_execute(struct nuodb *db, const char *sql, int64_t *rows_affected, int64_t *last_insert_id);
+int nuodb_execute(struct nuodb *db, const char *sql, int64_t *rows_affected, int64_t *last_insert_id, int64_t timeout_micro_seconds);
 
 int nuodb_statement_prepare(struct nuodb *db, const char *sql, struct nuodb_statement **st, int *parameter_count);
 int nuodb_statement_bind(struct nuodb *db, struct nuodb_statement *st, struct nuodb_value parameters[]);
 int nuodb_statement_execute(struct nuodb *db, struct nuodb_statement *st, int64_t *rows_affected, int64_t *last_insert_id);
 int nuodb_statement_query(struct nuodb *db, struct nuodb_statement *st, struct nuodb_resultset **rs, int *column_count);
 int nuodb_statement_close(struct nuodb *db, struct nuodb_statement **st);
+int nuodb_statement_set_query_micros(struct nuodb *db, struct nuodb_statement *st, int64_t timeout_micro_seconds);
 
 int nuodb_resultset_column_names(struct nuodb *db, struct nuodb_resultset *rs, struct nuodb_value names[]);
 int nuodb_resultset_next(struct nuodb *db, struct nuodb_resultset *rs, int *has_values, struct nuodb_value values[]);

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tilinna/go-nuodb
+
+go 1.13

--- a/nuodb.go
+++ b/nuodb.go
@@ -35,6 +35,12 @@ type Stmt struct {
 	ddlStatement   bool
 }
 
+var _ interface {
+	driver.Stmt
+	driver.StmtQueryContext
+	// driver.StmtExecContext
+} = (*Stmt)(nil)
+
 type Result struct {
 	rowsAffected C.int64_t
 	lastInsertId C.int64_t
@@ -360,6 +366,9 @@ func (stmt *Stmt) addTimeoutFromContext(ctx context.Context) error {
 	return nil
 }
 
+// getMicrosecondsUntilDeadline returns the number of micro seconds until the context's deadline is reached.
+// Returns an error if the context is already done.
+// N.B. A value of zero means no limit.
 func getMicrosecondsUntilDeadline(ctx context.Context) (uSec C.int64_t, err error) {
 	if deadline, ok := ctx.Deadline(); ok {
 		uSec = C.int64_t(time.Until(deadline).Microseconds())


### PR DESCRIPTION
### Overview

The Golang SQL library can pass a context to the `exec` and `query` function. This MR adds a simple implementation of the context functions.

The [NuoDB C++ API](https://doc.nuodb.com/nuodb/latest/api/c++/class_nuo_d_b_1_1_statement.html#a862b05b6dc7e1e499bf92fbe25955ef0) offers a function to set a timeout in micro seconds. 

The function will look on the provided context for a deadline and will set the timeout on the statement accordingly.

#### Caveat
The context will only be taken into account only if a timeout was set on the context. Passing a context that is simply cancelled by the caller will not have any effect on the request. Note that this is already the case as a caller can provide a context to the SQL call and the library will simply ignore it because this driver did not implement the require functions.
