### PR TITLE
prevent empty string panic

### DIFF
--- a/nuodb.go
+++ b/nuodb.go
@@ -250,11 +250,15 @@ func (stmt *Stmt) bind(args []driver.Value) error {
 			b := []byte(v)
 			args[i] = b // ensure the b is not GC'ed before the _bind
 			i32 = C.int32_t(len(v))
-			i64 = C.int64_t(uintptr(unsafe.Pointer(&b[0])))
+			if len(b) > 0 {
+				i64 = C.int64_t(uintptr(unsafe.Pointer(&b[0])))
+			}
 		case []byte:
 			vt = C.NUODB_TYPE_BYTES
 			i32 = C.int32_t(len(v))
-			i64 = C.int64_t(uintptr(unsafe.Pointer(&v[0])))
+			if len(v) > 0 {
+				i64 = C.int64_t(uintptr(unsafe.Pointer(&v[0])))
+			}
 		case time.Time:
 			vt = C.NUODB_TYPE_TIME
 			i32 = C.int32_t(v.Nanosecond())

--- a/nuodb_test.go
+++ b/nuodb_test.go
@@ -213,6 +213,39 @@ func TestExecAndQuery(t *testing.T) {
 	}
 }
 
+func TestEmptyStringAsStatementValue(t *testing.T) {
+	db := testConn(t)
+	defer db.Close()
+
+	id, ra := exec(t, db, "CREATE TABLE FooBar (id string)")
+	if id|ra != 0 {
+		t.Fatal(id, ra)
+	}
+
+	// Insert an empty string by value alongside a control value.
+	id, ra = exec(t, db, "INSERT INTO FooBar (id) VALUES (?),(?)", "", "control")
+	if id|ra == 0 {
+		t.Fatal(id, ra)
+	}
+
+	// Fetch back only empty string value.
+	rows := query(t, db, "SELECT * FROM FooBar where id = ?", "")
+	if !rows.Next() {
+		t.Fatal("Should have rows", rows)
+	}
+	values := [1]string{}
+	if err := rows.Scan(&values[0]); err != nil {
+		t.Fatal("Unable to scan:", err)
+	}
+
+	if values != [1]string{""} {
+		t.Fatal("Unexpected:", values)
+	}
+	if rows.Next() {
+		log.Fatal("Should only have one row", rows)
+	}
+}
+
 func TestExecAndQueryContext(t *testing.T) {
 	db := testConn(t)
 	defer db.Close()


### PR DESCRIPTION
### Overview
There is a panic if passing an argument that is an empty string or an empty byte.

### Solution (hackish)
Leave the value as default initialized and rely on the zero length passed to NuoDB to assume nothing will be copied from memory.

This is solutions relies on assumptions has to the way the NuoDB clients behaves. Additional branching in the .cpp code might be preferable to pass empty values and diminish the number of assumptions.